### PR TITLE
Training parameters (lr and weight decay) change. 

### DIFF
--- a/trainer.py
+++ b/trainer.py
@@ -114,6 +114,7 @@ class Trainer:
         train_ys = []
 
         test_accs = []
+	
         for inc_i in range(dataset.batch_num):
             print(f"Incremental num : {inc_i}")
             train, val, test = dataset.getNextClasses(inc_i)
@@ -137,7 +138,11 @@ class Trainer:
                         batch_size=batch_size, shuffle=False)
             test_data = DataLoader(BatchData(test_xs, test_ys, self.input_transform_eval),
                         batch_size=batch_size, shuffle=False)
-            optimizer = optim.SGD(self.model.parameters(), lr=lr, momentum=0.9,  weight_decay=2e-4)
+
+            weight_decay = 2e-4 * dataset.batch_num / (inc_i + 1)
+            print(f"Incremental num : {inc_i} with decay :{weight_decay}")
+
+            optimizer = optim.SGD(self.model.parameters(), lr=lr, momentum=0.9,  weight_decay=weight_decay)
             # scheduler = LambdaLR(optimizer, lr_lambda=adjust_cifar100)
             # scheduler = StepLR(optimizer, step_size=70, gamma=0.1)
             scheduler = MultiStepLR(optimizer, milestones=[100, 150, 200], gamma=0.1)
@@ -187,7 +192,6 @@ class Trainer:
             test_acc.append(acc)
             test_accs.append(max(test_acc))
             print(test_accs)
-            exit()
 
 
     def bias_forward(self, input):

--- a/trainer.py
+++ b/trainer.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.optim as optim
 from torchvision.transforms import Compose, CenterCrop, Normalize, Scale, Resize, ToTensor, ToPILImage
-from torch.optim.lr_scheduler import LambdaLR, StepLR
+from torch.optim.lr_scheduler import LambdaLR, StepLR, MultiStepLR
 
 import numpy as np
 import glob
@@ -32,7 +32,7 @@ class Trainer:
         self.dataset = Cifar100()
         self.model = PreResNet(32,total_cls).cuda()
         print(self.model)
-        self.model = nn.DataParallel(self.model, device_ids=[0,1])
+        self.model = nn.DataParallel(self.model, device_ids=[0,1,2,3])
         self.bias_layer1 = BiasLayer().cuda()
         self.bias_layer2 = BiasLayer().cuda()
         self.bias_layer3 = BiasLayer().cuda()
@@ -139,7 +139,8 @@ class Trainer:
                         batch_size=batch_size, shuffle=False)
             optimizer = optim.SGD(self.model.parameters(), lr=lr, momentum=0.9,  weight_decay=2e-4)
             # scheduler = LambdaLR(optimizer, lr_lambda=adjust_cifar100)
-            scheduler = StepLR(optimizer, step_size=70, gamma=0.1)
+            # scheduler = StepLR(optimizer, step_size=70, gamma=0.1)
+            scheduler = MultiStepLR(optimizer, milestones=[100, 150, 200], gamma=0.1)
 
 
             # bias_optimizer = optim.SGD(self.bias_layers[inc_i].parameters(), lr=lr, momentum=0.9)
@@ -186,6 +187,7 @@ class Trainer:
             test_acc.append(acc)
             test_accs.append(max(test_acc))
             print(test_accs)
+            exit()
 
 
     def bias_forward(self, input):


### PR DESCRIPTION
Change the lr schedule from steplr to multistep lr following the paper. Change weight decay according to the incremental stages. Early stages have larger weight decay than late stages. I got one close result [0.856, 0.72125, 0.6556666666666666, 0.6015, 0.5577], see the log file in the folder logs. 

The distillation part is also different from our implementation. But I think your implementation is kind of fine.